### PR TITLE
Add dry-run and option to exclude package names from deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ This action deletes versions of a package from [GitHub Packages](https://github.
   #   If `package-version-ids` is given the token only needs the delete packages scope.
   #   If `package-version-ids` is not given the token needs the delete packages scope and the read packages scope
   token:
+
+  # Perform a dry-run: only print out actions to be performed without actually deleting anything.
+  # Defaults to false.
+  dry-run:
 ```
 
 # Scenarios

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This action deletes versions of a package from [GitHub Packages](https://github.
 * Delete multiple versions
 * Delete specific version(s) 
 * Delete oldest version(s)
+* Delete oldest version(s) while ignoring a specific version pattern
 * Delete version(s) of a package that is hosted in the same repo that is executing the workflow
 * Delete version(s) of a package that is hosted in a different repo than the one executing the workflow
 
@@ -19,7 +20,13 @@ This action deletes versions of a package from [GitHub Packages](https://github.
   # Can be a single package version id, or a comma separated list of package version ids.
   # Defaults to an empty string.
   package-version-ids:
-  
+
+  # Regular expression string matching package version names to never delete.
+  # This has no effect when explicitly specifying package version ids using package-version-ids.
+  # As a result of the match, less than num-old-versions-to-delete may be deleted.
+  # Defaults to allowing all packages.
+  ignored-version-names:
+
   # Owner of the repo hosting the package.
   # Defaults to the owner of the repo executing the workflow.
   # Required if deleting a version from a package hosted in a different repo than the one executing the workflow.
@@ -60,6 +67,7 @@ This action deletes versions of a package from [GitHub Packages](https://github.
 * [Delete oldest version of a package hosted in the same repo as the workflow](#delete-oldest-version-of-a-package-hosted-in-the-same-repo-as-the-workflow)
 * [Delete oldest x number of versions of a package hosted in the same repo as the workflow](#delete-oldest-x-number-of-versions-of-a-package-hosted-in-the-same-repo-as-the-workflow)
 * [Delete oldest x number of versions of a package hosted in a different repo than the workflow](#delete-oldest-x-number-of-versions-of-a-package-hosted-in-a-different-repo-than-the-workflow)
+* [Delete oldest x number of versions of a package excluding packages whose name matches a given pattern](#delete-oldest-x-number-of-versions-of-a-package-excluding-packages-whose-name-matches-a-given-pattern)
 
 ### Delete a specific version of a package hosted in the same repo as the workflow
 
@@ -199,6 +207,18 @@ Delete the oldest 3 version of a package hosted in a different repo than the one
     package-name: 'test-package'
     num-old-versions-to-delete: 3
     token: ${{ secrets.GITHUB_PAT }}
+```
+
+### Delete oldest x number of versions of a package excluding packages whose name matches a given pattern
+
+To delete the oldest x nubmer of versions of a package, but exclude packages whost name matches a given pattern from being deleted.
+
+```yaml
+- uses: actions/delete-package-versions@v1
+  with:
+    package-name: 'test-package'
+    num-old-versions-to-delete: 3
+    ignored-version-names: "docker-base-layer|^\\d+\\.\\d+$"
 ```
 
 # License

--- a/__tests__/delete.test.ts
+++ b/__tests__/delete.test.ts
@@ -74,6 +74,13 @@ describe.skip('index tests -- call graphql', () => {
       }
     )
   })
+
+  it('deleteVersions test -- dry run', done => {
+    deleteVersions(getInput({dryRun: true})).subscribe(isSuccess => {
+      expect(isSuccess).toBe(true)
+      done()
+    })
+  })
 })
 
 const defaultInput: InputParams = {
@@ -82,7 +89,8 @@ const defaultInput: InputParams = {
   repo: 'actions-testing',
   packageName: 'com.github.trent-j.actions-test',
   numOldVersionsToDelete: 1,
-  token: process.env.GITHUB_TOKEN as string
+  token: process.env.GITHUB_TOKEN as string,
+  dryRun: false
 }
 
 function getInput(params?: InputParams): Input {

--- a/__tests__/version/delete-version.test.ts
+++ b/__tests__/version/delete-version.test.ts
@@ -11,6 +11,15 @@ describe.skip('delete tests', () => {
     expect(response).toBe(true)
   })
 
+  it('deletePackageVersion (dry-run)', async () => {
+    const response = await deletePackageVersion(
+      'MDE0OlBhY2thZ2VWZXJzaW9uNjg5OTU1',
+      githubToken,
+      true
+    ).toPromise()
+    expect(response).toBe(true)
+  })
+
   it('deletePackageVersions', async () => {
     const response = await deletePackageVersions(
       [
@@ -19,6 +28,19 @@ describe.skip('delete tests', () => {
         'MDE0OlBhY2thZ2VWZXJzaW9uNjk4MjY3'
       ],
       githubToken
+    ).toPromise()
+    expect(response).toBe(true)
+  })
+
+  it('deletePackageVersions', async () => {
+    const response = await deletePackageVersions(
+      [
+        'MDE0OlBhY2thZ2VWZXJzaW9uNjk4Mjc0',
+        'MDE0OlBhY2thZ2VWZXJzaW9uNjk4Mjcx',
+        'MDE0OlBhY2thZ2VWZXJzaW9uNjk4MjY3'
+      ],
+      githubToken,
+      true
     ).toPromise()
     expect(response).toBe(true)
   })

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,12 @@ inputs:
     required: false
     default: ${{ github.token }}
 
+  dry-run:
+    description: >
+      Only print the versions that will be deleted without actually deleting them.
+    required: false
+    default: "false"
+
 runs:
   using: node12
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,14 @@ inputs:
     description: Comma separated string of package version ids to delete.
     required: false
 
+  ignored-version-names:
+    description: >
+      Regular expression string matching package version names to never delete.
+      This has no effect when explicitly specifying package version ids using package-version-ids.
+      As a result of the match, less than num-old-versions-to-delete may be deleted.
+    required: false
+    default: "^(?!.*)$"
+
   owner:
     description: >
       Owner of the repo containing the package version to delete.

--- a/dist/index.js
+++ b/dist/index.js
@@ -6014,11 +6014,13 @@ function getActionInput() {
         packageVersionIds: core_1.getInput('package-version-ids')
             ? core_1.getInput('package-version-ids').split(',')
             : [],
+        ignoredVersions: RegExp(core_1.getInput('ignored-version-names')),
         owner: core_1.getInput('owner') ? core_1.getInput('owner') : github_1.context.repo.owner,
         repo: core_1.getInput('repo') ? core_1.getInput('repo') : github_1.context.repo.repo,
         packageName: core_1.getInput('package-name'),
         numOldVersionsToDelete: Number(core_1.getInput('num-old-versions-to-delete')),
-        token: core_1.getInput('token')
+        token: core_1.getInput('token'),
+        dryRun: Boolean(core_1.getInput('dry-run'))
     });
 }
 function run() {
@@ -6320,7 +6322,7 @@ exports.BehaviorSubject = BehaviorSubject;
 /* 215 */
 /***/ (function(module) {
 
-module.exports = {"_from":"@octokit/rest@^16.43.1","_id":"@octokit/rest@16.43.1","_inBundle":false,"_integrity":"sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==","_location":"/@octokit/rest","_phantomChildren":{},"_requested":{"type":"range","registry":true,"raw":"@octokit/rest@^16.43.1","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"^16.43.1","saveSpec":null,"fetchSpec":"^16.43.1"},"_requiredBy":["/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz","_shasum":"3b11e7d1b1ac2bbeeb23b08a17df0b20947eda6b","_spec":"@octokit/rest@^16.43.1","_where":"/Users/trentj/Projects/delete-package-versions/node_modules/@actions/github","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundleDependencies":false,"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"deprecated":false,"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:ts":"npm run -s update-endpoints:typescript","coverage":"nyc report --reporter=html && open coverage/index.html","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","pretest":"npm run -s lint","prevalidate:ts":"npm run -s build:ts","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"types":"index.d.ts","version":"16.43.1"};
+module.exports = {"_args":[["@octokit/rest@16.43.1","/c/Repos/matsuri/delete-package-versions"]],"_from":"@octokit/rest@16.43.1","_id":"@octokit/rest@16.43.1","_inBundle":false,"_integrity":"sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==","_location":"/@octokit/rest","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@octokit/rest@16.43.1","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"16.43.1","saveSpec":null,"fetchSpec":"16.43.1"},"_requiredBy":["/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz","_spec":"16.43.1","_where":"/c/Repos/matsuri/delete-package-versions","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:ts":"npm run -s update-endpoints:typescript","coverage":"nyc report --reporter=html && open coverage/index.html","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","pretest":"npm run -s lint","prevalidate:ts":"npm run -s build:ts","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"types":"index.d.ts","version":"16.43.1"};
 
 /***/ }),
 /* 216 */
@@ -6445,7 +6447,10 @@ const mutation = `
           success
       }
   }`;
-function deletePackageVersion(packageVersionId, token) {
+function deletePackageVersion(packageVersionId, token, dryRun = false) {
+    if (dryRun) {
+        return rxjs_1.of(true);
+    }
     return rxjs_1.from(graphql_1.graphql(mutation, {
         packageVersionId,
         headers: {
@@ -6460,12 +6465,12 @@ function deletePackageVersion(packageVersionId, token) {
     }), operators_1.map(response => response.deletePackageVersion.success));
 }
 exports.deletePackageVersion = deletePackageVersion;
-function deletePackageVersions(packageVersionIds, token) {
+function deletePackageVersions(packageVersionIds, token, dryRun = false) {
     if (packageVersionIds.length === 0) {
         console.log('no package version ids found, no versions will be deleted');
         return rxjs_1.of(true);
     }
-    const deletes = packageVersionIds.map(id => deletePackageVersion(id, token).pipe(operators_1.tap(result => {
+    const deletes = packageVersionIds.map(id => deletePackageVersion(id, token, dryRun).pipe(operators_1.tap(result => {
         if (result) {
             console.log(`version with id: ${id}, deleted`);
         }
@@ -13905,21 +13910,25 @@ exports.TimeInterval = TimeInterval;
 Object.defineProperty(exports, "__esModule", { value: true });
 const defaultParams = {
     packageVersionIds: [],
+    ignoredVersions: new RegExp('^(?!.*)$'),
     owner: '',
     repo: '',
     packageName: '',
     numOldVersionsToDelete: 0,
-    token: ''
+    token: '',
+    dryRun: false
 };
 class Input {
     constructor(params) {
         const validatedParams = Object.assign(Object.assign({}, defaultParams), params);
         this.packageVersionIds = validatedParams.packageVersionIds;
+        this.ignoredVersions = validatedParams.ignoredVersions;
         this.owner = validatedParams.owner;
         this.repo = validatedParams.repo;
         this.packageName = validatedParams.packageName;
         this.numOldVersionsToDelete = validatedParams.numOldVersionsToDelete;
         this.token = validatedParams.token;
+        this.dryRun = validatedParams.dryRun;
     }
     hasOldestVersionQueryInfo() {
         return !!(this.owner &&
@@ -15762,7 +15771,9 @@ function getVersionIds(input) {
         return rxjs_1.of(input.packageVersionIds);
     }
     if (input.hasOldestVersionQueryInfo()) {
-        return version_1.getOldestVersions(input.owner, input.repo, input.packageName, input.numOldVersionsToDelete, input.token).pipe(operators_1.map(versionInfo => versionInfo.map(info => info.id)));
+        return version_1.getOldestVersions(input.owner, input.repo, input.packageName, input.numOldVersionsToDelete, input.token).pipe(operators_1.map(versionInfo => versionInfo
+            .filter(info => !input.ignoredVersions.test(info.version))
+            .map(info => info.id)));
     }
     return rxjs_1.throwError("Could not get packageVersionIds. Explicitly specify using the 'package-version-ids' input or provide the 'package-name' and 'num-old-versions-to-delete' inputs to dynamically retrieve oldest versions");
 }
@@ -15775,7 +15786,7 @@ function deleteVersions(input) {
         console.log('Number of old versions to delete input is 0 or less, no versions will be deleted');
         return rxjs_1.of(true);
     }
-    return getVersionIds(input).pipe(operators_1.concatMap(ids => version_1.deletePackageVersions(ids, input.token)));
+    return getVersionIds(input).pipe(operators_1.concatMap(ids => version_1.deletePackageVersions(ids, input.token, input.dryRun)));
 }
 exports.deleteVersions = deleteVersions;
 

--- a/src/delete.ts
+++ b/src/delete.ts
@@ -36,6 +36,6 @@ export function deleteVersions(input: Input): Observable<boolean> {
   }
 
   return getVersionIds(input).pipe(
-    concatMap(ids => deletePackageVersions(ids, input.token))
+    concatMap(ids => deletePackageVersions(ids, input.token, input.dryRun))
   )
 }

--- a/src/delete.ts
+++ b/src/delete.ts
@@ -15,7 +15,13 @@ export function getVersionIds(input: Input): Observable<string[]> {
       input.packageName,
       input.numOldVersionsToDelete,
       input.token
-    ).pipe(map(versionInfo => versionInfo.map(info => info.id)))
+    ).pipe(
+      map(versionInfo =>
+        versionInfo
+          .filter(info => !input.ignoredVersions.test(info.version))
+          .map(info => info.id)
+      )
+    )
   }
 
   return throwError(

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,5 +1,6 @@
 export interface InputParams {
   packageVersionIds?: string[]
+  ignoredVersions?: RegExp
   owner?: string
   repo?: string
   packageName?: string
@@ -10,6 +11,7 @@ export interface InputParams {
 
 const defaultParams = {
   packageVersionIds: [],
+  ignoredVersions: new RegExp('^(?!.*)$'),
   owner: '',
   repo: '',
   packageName: '',
@@ -20,6 +22,7 @@ const defaultParams = {
 
 export class Input {
   packageVersionIds: string[]
+  ignoredVersions: RegExp
   owner: string
   repo: string
   packageName: string
@@ -31,6 +34,7 @@ export class Input {
     const validatedParams: Required<InputParams> = {...defaultParams, ...params}
 
     this.packageVersionIds = validatedParams.packageVersionIds
+    this.ignoredVersions = validatedParams.ignoredVersions
     this.owner = validatedParams.owner
     this.repo = validatedParams.repo
     this.packageName = validatedParams.packageName

--- a/src/input.ts
+++ b/src/input.ts
@@ -5,6 +5,7 @@ export interface InputParams {
   packageName?: string
   numOldVersionsToDelete?: number
   token?: string
+  dryRun?: boolean
 }
 
 const defaultParams = {
@@ -13,7 +14,8 @@ const defaultParams = {
   repo: '',
   packageName: '',
   numOldVersionsToDelete: 0,
-  token: ''
+  token: '',
+  dryRun: false
 }
 
 export class Input {
@@ -23,6 +25,7 @@ export class Input {
   packageName: string
   numOldVersionsToDelete: number
   token: string
+  dryRun: boolean
 
   constructor(params?: InputParams) {
     const validatedParams: Required<InputParams> = {...defaultParams, ...params}
@@ -33,6 +36,7 @@ export class Input {
     this.packageName = validatedParams.packageName
     this.numOldVersionsToDelete = validatedParams.numOldVersionsToDelete
     this.token = validatedParams.token
+    this.dryRun = validatedParams.dryRun
   }
 
   hasOldestVersionQueryInfo(): boolean {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ function getActionInput(): Input {
     packageVersionIds: getInput('package-version-ids')
       ? getInput('package-version-ids').split(',')
       : [],
+    ignoredVersions: RegExp(getInput('ignored-version-names')),
     owner: getInput('owner') ? getInput('owner') : context.repo.owner,
     repo: getInput('repo') ? getInput('repo') : context.repo.repo,
     packageName: getInput('package-name'),

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,8 @@ function getActionInput(): Input {
     repo: getInput('repo') ? getInput('repo') : context.repo.repo,
     packageName: getInput('package-name'),
     numOldVersionsToDelete: Number(getInput('num-old-versions-to-delete')),
-    token: getInput('token')
+    token: getInput('token'),
+    dryRun: Boolean(getInput('dry-run'))
   })
 }
 

--- a/src/version/delete-version.ts
+++ b/src/version/delete-version.ts
@@ -18,8 +18,12 @@ const mutation = `
 
 export function deletePackageVersion(
   packageVersionId: string,
-  token: string
+  token: string,
+  dryRun = false
 ): Observable<boolean> {
+  if (dryRun) {
+    return of(true)
+  }
   return from(
     graphql(mutation, {
       packageVersionId,
@@ -43,7 +47,8 @@ export function deletePackageVersion(
 
 export function deletePackageVersions(
   packageVersionIds: string[],
-  token: string
+  token: string,
+  dryRun = false
 ): Observable<boolean> {
   if (packageVersionIds.length === 0) {
     console.log('no package version ids found, no versions will be deleted')
@@ -51,7 +56,7 @@ export function deletePackageVersions(
   }
 
   const deletes = packageVersionIds.map(id =>
-    deletePackageVersion(id, token).pipe(
+    deletePackageVersion(id, token, dryRun).pipe(
       tap(result => {
         if (result) {
           console.log(`version with id: ${id}, deleted`)


### PR DESCRIPTION
This PR adds two new configuration features:
- A `dry-run` option to only print out the IDs of packages to be deleted without actually performing any destructive actions
- A `ignore-package-names` option allowing to provide a regular expression to specify package names to exclude from deletion

The second feature should address use cases like those in #6. For instance, with package names
```
- 4.20
- 4.21
- 4.20.20200329
- 4.21.20200330
```

And the following configuration:
```yaml
with: 
  ignored-version-names: "docker-base-layer|^\\d+\\.\\d+$"
  num-old-versions-to-delete: "5"
```
Only `4.20.20200329` and `4.21.20200330` would be deleted. As the current GraphQL API doesn't allow to query packages with a filter pattern, filtering is done after retrieving the last N packages. As a result, less than N packages may be deleted, which admittedly may be contrary to user expectation (though the same happens when requesting N older packages when there are less than N).