### PR TITLE
Add dry-run parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ This action deletes versions of a package from [GitHub Packages](https://github.
   #   If `package-version-ids` is given the token only needs the delete packages scope.
   #   If `package-version-ids` is not given the token needs the delete packages scope and the read packages scope
   token:
+
+  # Perform a dry-run: only print out actions to be performed without actually deleting anything.
+  # Defaults to false.
+  dry-run:
 ```
 
 # Scenarios

--- a/__tests__/delete.test.ts
+++ b/__tests__/delete.test.ts
@@ -74,6 +74,13 @@ describe.skip('index tests -- call graphql', () => {
       }
     )
   })
+
+  it('deleteVersions test -- dry run', done => {
+    deleteVersions(getInput({dryRun: true})).subscribe(isSuccess => {
+      expect(isSuccess).toBe(true)
+      done()
+    })
+  })
 })
 
 const defaultInput: InputParams = {
@@ -82,7 +89,8 @@ const defaultInput: InputParams = {
   repo: 'actions-testing',
   packageName: 'com.github.trent-j.actions-test',
   numOldVersionsToDelete: 1,
-  token: process.env.GITHUB_TOKEN as string
+  token: process.env.GITHUB_TOKEN as string,
+  dryRun: false
 }
 
 function getInput(params?: InputParams): Input {

--- a/__tests__/version/delete-version.test.ts
+++ b/__tests__/version/delete-version.test.ts
@@ -11,6 +11,15 @@ describe.skip('delete tests', () => {
     expect(response).toBe(true)
   })
 
+  it('deletePackageVersion (dry-run)', async () => {
+    const response = await deletePackageVersion(
+      'MDE0OlBhY2thZ2VWZXJzaW9uNjg5OTU1',
+      githubToken,
+      true
+    ).toPromise()
+    expect(response).toBe(true)
+  })
+
   it('deletePackageVersions', async () => {
     const response = await deletePackageVersions(
       [
@@ -19,6 +28,19 @@ describe.skip('delete tests', () => {
         'MDE0OlBhY2thZ2VWZXJzaW9uNjk4MjY3'
       ],
       githubToken
+    ).toPromise()
+    expect(response).toBe(true)
+  })
+
+  it('deletePackageVersions', async () => {
+    const response = await deletePackageVersions(
+      [
+        'MDE0OlBhY2thZ2VWZXJzaW9uNjk4Mjc0',
+        'MDE0OlBhY2thZ2VWZXJzaW9uNjk4Mjcx',
+        'MDE0OlBhY2thZ2VWZXJzaW9uNjk4MjY3'
+      ],
+      githubToken,
+      true
     ).toPromise()
     expect(response).toBe(true)
   })

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,12 @@ inputs:
     required: false
     default: ${{ github.token }}
 
+  dry-run:
+    description: >
+      Only print the versions that will be deleted without actually deleting them.
+    required: false
+    default: "false"
+
 runs:
   using: node12
   main: dist/index.js

--- a/src/delete.ts
+++ b/src/delete.ts
@@ -36,6 +36,6 @@ export function deleteVersions(input: Input): Observable<boolean> {
   }
 
   return getVersionIds(input).pipe(
-    concatMap(ids => deletePackageVersions(ids, input.token))
+    concatMap(ids => deletePackageVersions(ids, input.token, input.dryRun))
   )
 }

--- a/src/input.ts
+++ b/src/input.ts
@@ -5,6 +5,7 @@ export interface InputParams {
   packageName?: string
   numOldVersionsToDelete?: number
   token?: string
+  dryRun?: boolean
 }
 
 const defaultParams = {
@@ -13,7 +14,8 @@ const defaultParams = {
   repo: '',
   packageName: '',
   numOldVersionsToDelete: 0,
-  token: ''
+  token: '',
+  dryRun: false
 }
 
 export class Input {
@@ -23,6 +25,7 @@ export class Input {
   packageName: string
   numOldVersionsToDelete: number
   token: string
+  dryRun: boolean
 
   constructor(params?: InputParams) {
     const validatedParams: Required<InputParams> = {...defaultParams, ...params}
@@ -33,6 +36,7 @@ export class Input {
     this.packageName = validatedParams.packageName
     this.numOldVersionsToDelete = validatedParams.numOldVersionsToDelete
     this.token = validatedParams.token
+    this.dryRun = validatedParams.dryRun
   }
 
   hasOldestVersionQueryInfo(): boolean {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,8 @@ function getActionInput(): Input {
     repo: getInput('repo') ? getInput('repo') : context.repo.repo,
     packageName: getInput('package-name'),
     numOldVersionsToDelete: Number(getInput('num-old-versions-to-delete')),
-    token: getInput('token')
+    token: getInput('token'),
+    dryRun: Boolean(getInput('dry-run'))
   })
 }
 

--- a/src/version/delete-version.ts
+++ b/src/version/delete-version.ts
@@ -18,8 +18,12 @@ const mutation = `
 
 export function deletePackageVersion(
   packageVersionId: string,
-  token: string
+  token: string,
+  dryRun = false
 ): Observable<boolean> {
+  if (dryRun) {
+    return of(true)
+  }
   return from(
     graphql(mutation, {
       packageVersionId,
@@ -43,7 +47,8 @@ export function deletePackageVersion(
 
 export function deletePackageVersions(
   packageVersionIds: string[],
-  token: string
+  token: string,
+  dryRun = false
 ): Observable<boolean> {
   if (packageVersionIds.length === 0) {
     console.log('no package version ids found, no versions will be deleted')
@@ -51,7 +56,7 @@ export function deletePackageVersions(
   }
 
   const deletes = packageVersionIds.map(id =>
-    deletePackageVersion(id, token).pipe(
+    deletePackageVersion(id, token, dryRun).pipe(
       tap(result => {
         if (result) {
           console.log(`version with id: ${id}, deleted`)


### PR DESCRIPTION
This PR contains the changes proposed in #8 but split into two PRs: one for each proposed feature. This one provides the `dry-run` option to only print ont the IDs of packages to be deleted without actually performing any destructive actions. We find this useful to test out CI settings without causing permanent package deletions.