### PR TITLE
Add option to exclude package names from deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This action deletes versions of a package from [GitHub Packages](https://github.
 * Delete multiple versions
 * Delete specific version(s) 
 * Delete oldest version(s)
+* Delete oldest version(s) while ignoring a specific version pattern
 * Delete version(s) of a package that is hosted in the same repo that is executing the workflow
 * Delete version(s) of a package that is hosted in a different repo than the one executing the workflow
 
@@ -19,7 +20,13 @@ This action deletes versions of a package from [GitHub Packages](https://github.
   # Can be a single package version id, or a comma separated list of package version ids.
   # Defaults to an empty string.
   package-version-ids:
-  
+
+  # Regular expression string matching package version names to never delete.
+  # This has no effect when explicitly specifying package version ids using package-version-ids.
+  # As a result of the match, less than num-old-versions-to-delete may be deleted.
+  # Defaults to allowing all packages.
+  ignored-version-names:
+
   # Owner of the repo hosting the package.
   # Defaults to the owner of the repo executing the workflow.
   # Required if deleting a version from a package hosted in a different repo than the one executing the workflow.
@@ -56,6 +63,7 @@ This action deletes versions of a package from [GitHub Packages](https://github.
 * [Delete oldest version of a package hosted in the same repo as the workflow](#delete-oldest-version-of-a-package-hosted-in-the-same-repo-as-the-workflow)
 * [Delete oldest x number of versions of a package hosted in the same repo as the workflow](#delete-oldest-x-number-of-versions-of-a-package-hosted-in-the-same-repo-as-the-workflow)
 * [Delete oldest x number of versions of a package hosted in a different repo than the workflow](#delete-oldest-x-number-of-versions-of-a-package-hosted-in-a-different-repo-than-the-workflow)
+* [Delete oldest x number of versions of a package excluding packages whose name matches a given pattern](#delete-oldest-x-number-of-versions-of-a-package-excluding-packages-whose-name-matches-a-given-pattern)
 
 ### Delete a specific version of a package hosted in the same repo as the workflow
 
@@ -195,6 +203,18 @@ Delete the oldest 3 version of a package hosted in a different repo than the one
     package-name: 'test-package'
     num-old-versions-to-delete: 3
     token: ${{ secrets.GITHUB_PAT }}
+```
+
+### Delete oldest x number of versions of a package excluding packages whose name matches a given pattern
+
+To delete the oldest x nubmer of versions of a package, but exclude packages whost name matches a given pattern from being deleted.
+
+```yaml
+- uses: actions/delete-package-versions@v1
+  with:
+    package-name: 'test-package'
+    num-old-versions-to-delete: 3
+    ignored-version-names: "docker-base-layer|^\\d+\\.\\d+$"
 ```
 
 # License

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,14 @@ inputs:
     description: Comma separated string of package version ids to delete.
     required: false
 
+  ignored-version-names:
+    description: >
+      Regular expression string matching package version names to never delete.
+      This has no effect when explicitly specifying package version ids using package-version-ids.
+      As a result of the match, less than num-old-versions-to-delete may be deleted.
+    required: false
+    default: "^(?!.*)$"
+
   owner:
     description: >
       Owner of the repo containing the package version to delete.

--- a/src/delete.ts
+++ b/src/delete.ts
@@ -15,7 +15,13 @@ export function getVersionIds(input: Input): Observable<string[]> {
       input.packageName,
       input.numOldVersionsToDelete,
       input.token
-    ).pipe(map(versionInfo => versionInfo.map(info => info.id)))
+    ).pipe(
+      map(versionInfo =>
+        versionInfo
+          .filter(info => !input.ignoredVersions.test(info.version))
+          .map(info => info.id)
+      )
+    )
   }
 
   return throwError(

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,5 +1,6 @@
 export interface InputParams {
   packageVersionIds?: string[]
+  ignoredVersions?: RegExp
   owner?: string
   repo?: string
   packageName?: string
@@ -9,6 +10,7 @@ export interface InputParams {
 
 const defaultParams = {
   packageVersionIds: [],
+  ignoredVersions: new RegExp('^(?!.*)$'),
   owner: '',
   repo: '',
   packageName: '',
@@ -18,6 +20,7 @@ const defaultParams = {
 
 export class Input {
   packageVersionIds: string[]
+  ignoredVersions: RegExp
   owner: string
   repo: string
   packageName: string
@@ -28,6 +31,7 @@ export class Input {
     const validatedParams: Required<InputParams> = {...defaultParams, ...params}
 
     this.packageVersionIds = validatedParams.packageVersionIds
+    this.ignoredVersions = validatedParams.ignoredVersions
     this.owner = validatedParams.owner
     this.repo = validatedParams.repo
     this.packageName = validatedParams.packageName

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ function getActionInput(): Input {
     packageVersionIds: getInput('package-version-ids')
       ? getInput('package-version-ids').split(',')
       : [],
+    ignoredVersions: RegExp(getInput('ignored-version-names')),
     owner: getInput('owner') ? getInput('owner') : context.repo.owner,
     repo: getInput('repo') ? getInput('repo') : context.repo.repo,
     packageName: getInput('package-name'),


### PR DESCRIPTION
This PR contains the changes proposed in #8 but split into two PRs: one for each proposed feature. This one provides the `ignore-package-names` option allowing to provide a regular expression to specify package names to exclude from deletion. This should address use cases like those in #6. For instance, with package names
```
- 4.20
- 4.21
- 4.20.20200329
- 4.21.20200330
```
And the following configuration:
```yaml
with: 
  ignored-version-names: "docker-base-layer|^\\d+\\.\\d+$"
  num-old-versions-to-delete: "5"
```
Only `4.20.20200329` and `4.21.20200330` would be deleted. As the current GraphQL API doesn't allow to query packages with a filter pattern, filtering is done after retrieving the last N packages. As a result, less than N packages may be deleted, which admittedly may be contrary to user expectation (though the same happens when requesting N older packages when there are less than N).