### PR TITLE
Use @actions/github to invoke GraphQL for GHES compatibility

### DIFF
--- a/__tests__/version/graphql.mock.ts
+++ b/__tests__/version/graphql.mock.ts
@@ -3,17 +3,8 @@ import {
   RequestParameters
 } from '@octokit/graphql/dist-types/types'
 
-import * as Graphql from '@octokit/graphql'
+import * as Graphql from '../../src/version/graphql'
 import {GetVersionsQueryResponse} from '../../src/version'
-
-import SpyInstance = jest.SpyInstance
-
-export function mockGraphql(): SpyInstance<
-  Promise<GraphQlQueryResponseData>,
-  [string, (RequestParameters | undefined)?]
-> {
-  return jest.spyOn(Graphql, 'graphql')
-}
 
 export function getMockedOldestQueryResponse(
   numVersions: number
@@ -49,8 +40,10 @@ export function getMockedOldestQueryResponse(
 
 export function mockOldestQueryResponse(
   numVersions: number
-): ReturnType<typeof mockGraphql> {
-  return mockGraphql().mockResolvedValue(
-    getMockedOldestQueryResponse(numVersions)
-  )
+) {
+  const response = new Promise((resolve) => {
+    resolve(getMockedOldestQueryResponse(numVersions))
+  }) as Promise<GraphQlQueryResponseData>
+  jest.spyOn(Graphql, 'graphql').mockImplementation(
+    (token: string, query: string, parameters: RequestParameters) => response)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-ZKdyhlSlyz38S6YFfPnyNgCDZuAF2T0Qv5eHflNWytPS8Qjvz39bZFMry9Bb/dpSnqWcNeav5yM2CTYpJeY+Dw=="
     },
     "@actions/github": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-2.1.1.tgz",
-      "integrity": "sha512-kAgTGUx7yf5KQCndVeHSwCNZuDBvPyxm5xKTswW2lofugeuC1AZX73nUUVDNaysnM9aKFMHv9YCdVJbg7syEyA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-2.2.0.tgz",
+      "integrity": "sha512-9UAZqn8ywdR70n3GwVle4N8ALosQs4z50N7XMXrSTUVOmVpaBC5kE3TRTT7qQdi3OaQV24mjGuJZsHUmhD+ZXw==",
       "requires": {
         "@actions/http-client": "^1.0.3",
         "@octokit/graphql": "^4.3.1",
@@ -20,9 +20,9 @@
       }
     },
     "@actions/http-client": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.6.tgz",
-      "integrity": "sha512-LGmio4w98UyGX33b/W6V6Nx/sQHRXZ859YlMkn36wPsXPB82u8xTVlA/Dq2DXrm6lEq9RVmisRJa1c+HETAIJA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
+      "integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
       "requires": {
         "tunnel": "0.0.6"
       }
@@ -438,11 +438,11 @@
       }
     },
     "@octokit/endpoint": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.3.tgz",
-      "integrity": "sha512-EzKwkwcxeegYYah5ukEeAI/gYRLv2Y9U5PpIsseGSFDk+G3RbipQGBs8GuYS1TLCtQaqoO66+aQGtITPalxsNQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.1.tgz",
+      "integrity": "sha512-pOPHaSz57SFT/m3R5P8MUu4wLPszokn5pXcB/pzavLTQf2jbU+6iayTvzaY6/BiotuRS0qyEUkx3QglT4U958A==",
       "requires": {
-        "@octokit/types": "^2.0.0",
+        "@octokit/types": "^2.11.1",
         "is-plain-object": "^3.0.0",
         "universal-user-agent": "^5.0.0"
       },
@@ -459,25 +459,17 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
           "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
-        },
-        "universal-user-agent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-          "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-          "requires": {
-            "os-name": "^3.1.0"
-          }
         }
       }
     },
     "@octokit/graphql": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.3.1.tgz",
-      "integrity": "sha512-hCdTjfvrK+ilU2keAdqNBWOk+gm1kai1ZcdjRfB30oA3/T6n53UVJb7w0L5cR3/rhU91xT3HSqCd+qbvH06yxA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.4.0.tgz",
+      "integrity": "sha512-Du3hAaSROQ8EatmYoSAJjzAz3t79t9Opj/WY1zUgxVUGfIKn0AEjg+hlOLscF6fv6i/4y/CeUvsWgIfwMkTccw==",
       "requires": {
         "@octokit/request": "^5.3.0",
         "@octokit/types": "^2.0.0",
-        "universal-user-agent": "^4.0.0"
+        "universal-user-agent": "^5.0.0"
       }
     },
     "@octokit/plugin-paginate-rest": {
@@ -503,13 +495,13 @@
       }
     },
     "@octokit/request": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.2.tgz",
-      "integrity": "sha512-7NPJpg19wVQy1cs2xqXjjRq/RmtSomja/VSWnptfYwuBxLdbYh2UjhGi0Wx7B1v5Iw5GKhfFDQL7jM7SSp7K2g==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.2.tgz",
+      "integrity": "sha512-zKdnGuQ2TQ2vFk9VU8awFT4+EYf92Z/v3OlzRaSh4RIP0H6cvW1BFPXq4XYvNez+TPQjqN+0uSkCYnMFFhcFrw==",
       "requires": {
-        "@octokit/endpoint": "^5.5.0",
-        "@octokit/request-error": "^1.0.1",
-        "@octokit/types": "^2.0.0",
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^2.11.1",
         "deprecation": "^2.0.0",
         "is-plain-object": "^3.0.0",
         "node-fetch": "^2.3.0",
@@ -534,21 +526,13 @@
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
           "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-        },
-        "universal-user-agent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-          "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-          "requires": {
-            "os-name": "^3.1.0"
-          }
         }
       }
     },
     "@octokit/request-error": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
-      "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.0.tgz",
+      "integrity": "sha512-rtYicB4Absc60rUv74Rjpzek84UbVHGHJRu4fNVlZ1mCcyUPPuzFfG9Rn6sjHrd95DEsmjSt1Axlc699ZlbDkw==",
       "requires": {
         "@octokit/types": "^2.0.0",
         "deprecation": "^2.0.0",
@@ -576,12 +560,32 @@
         "octokit-pagination-methods": "^1.1.0",
         "once": "^1.4.0",
         "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "@octokit/request-error": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
+          "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
+          "requires": {
+            "@octokit/types": "^2.0.0",
+            "deprecation": "^2.0.0",
+            "once": "^1.4.0"
+          }
+        },
+        "universal-user-agent": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
+          "integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
+          "requires": {
+            "os-name": "^3.1.0"
+          }
+        }
       }
     },
     "@octokit/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-rvJP1Y9A/+Cky2C3var1vsw3Lf5Rjn/0sojNl2AjCX+WbpIHYccaJ46abrZoIxMYnOToul6S9tPytUVkFI7CXQ==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+      "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
       "requires": {
         "@types/node": ">= 8"
       }
@@ -6380,9 +6384,9 @@
       }
     },
     "universal-user-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
-      "integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
+      "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
       "requires": {
         "os-name": "^3.1.0"
       }
@@ -6556,9 +6560,9 @@
       "dev": true
     },
     "windows-release": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
-      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.0.tgz",
+      "integrity": "sha512-2HetyTg1Y+R+rUgrKeUEhAG/ZuOmTrI1NBb3ZyAGQMYmOJjBBPe4MTodghRkmLJZHwkuPi02anbeGP+Zf401LQ==",
       "requires": {
         "execa": "^1.0.0"
       }

--- a/src/version/delete-version.ts
+++ b/src/version/delete-version.ts
@@ -1,7 +1,7 @@
 import {from, Observable, merge, throwError, of} from 'rxjs'
-import {graphql} from '@octokit/graphql'
 import {catchError, map, tap} from 'rxjs/operators'
 import {GraphQlQueryResponse} from '@octokit/graphql/dist-types/types'
+import {graphql} from './graphql'
 
 export interface DeletePackageVersionMutationResponse {
   deletePackageVersion: {
@@ -21,10 +21,9 @@ export function deletePackageVersion(
   token: string
 ): Observable<boolean> {
   return from(
-    graphql(mutation, {
+    graphql(token, mutation, {
       packageVersionId,
       headers: {
-        authorization: `token ${token}`,
         Accept: 'application/vnd.github.package-deletes-preview+json'
       }
     }) as Promise<DeletePackageVersionMutationResponse>

--- a/src/version/get-versions.ts
+++ b/src/version/get-versions.ts
@@ -1,7 +1,7 @@
-import {graphql} from '@octokit/graphql'
 import {GraphQlQueryResponse} from '@octokit/graphql/dist-types/types'
 import {Observable, from, throwError} from 'rxjs'
 import {catchError, map} from 'rxjs/operators'
+import {graphql} from './graphql'
 
 export interface VersionInfo {
   id: string
@@ -52,13 +52,12 @@ export function queryForOldestVersions(
   token: string
 ): Observable<GetVersionsQueryResponse> {
   return from(
-    graphql(query, {
+    graphql(token, query, {
       owner,
       repo,
       package: packageName,
       last: numVersions,
       headers: {
-        authorization: `token ${token}`,
         Accept: 'application/vnd.github.packages-preview+json'
       }
     }) as Promise<GetVersionsQueryResponse>

--- a/src/version/graphql.ts
+++ b/src/version/graphql.ts
@@ -1,0 +1,19 @@
+import {GitHub} from '@actions/github'
+import {GraphQlQueryResponseData} from '@octokit/graphql/dist-types/types'
+import {RequestParameters} from '@octokit/types/dist-types/RequestParameters'
+
+/**
+ * Sends a GraphQL query request based on endpoint options
+ *
+ * @param {string} token Auth token
+ * @param {string} query GraphQL query. Example: `'query { viewer { login } }'`.
+ * @param {object} parameters URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
+ */
+export async function graphql(
+  token: string,
+  query: string,
+  parameters: RequestParameters
+): Promise<GraphQlQueryResponseData> {
+  const github = new GitHub(token)
+  return await github.graphql(query, parameters)
+}


### PR DESCRIPTION
Switched to `@actions/github@2.2.0` for GHES support when invoking GraphQL. It sets the correct baseUrl when running in a GHES environment. Related to PR https://github.com/actions/toolkit/pull/449