### PR TITLE
Upgrade to node16

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set Node.js 12.x
+      - name: Set Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
 
       - name: Install dependencies
         run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ inputs:
     default: ${{ github.token }}
 
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 
 branding:


### PR DESCRIPTION
Upgrading action to node16 as per [this](https://github.com/github/c2c-package-registry/issues/4701#issuecomment-1055688062). Changes of earlier [PR](https://github.com/actions/delete-package-versions/pull/62) had to be reverted for a v2 patch release.