### PR TITLE
Not currently supported in GHES

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ This action deletes versions of a package from [GitHub Packages](https://github.
     - [Delete oldest version of a package](#delete-oldest-version-of-a-package)
     - [Delete a specific version of a package](#delete-a-specific-version-of-a-package)
     - [Delete multiple specific versions of a package](#delete-multiple-specific-versions-of-a-package)
-- [GitHub Enterprise Server](#github-enterprise-server)
 - [License](#license)
 
 
@@ -400,10 +399,6 @@ This action deletes versions of a package from [GitHub Packages](https://github.
       package-type: 'npm'
       token: ${{ secrets.PAT }}
   ```
-
-# GitHub Enterprise Server
-
-This action works with GitHub Enterprise Server. It uses the `GITHUB_API_URL` environment variable to determine the GitHub Enterprise Server URL. The environment variable is automatically set in workflows. GitHub Connect should be configured on the server to allow using the action from GitHub.com. See - [Enabling automatic access to GitHub.com actions using GitHub Connect](https://docs.github.com/en/enterprise-server/admin/github-actions/managing-access-to-actions-from-githubcom/enabling-automatic-access-to-githubcom-actions-using-github-connect)
 
 # License
 


### PR DESCRIPTION
This action is not currently supported in GHES due to lack of Packages REST APIs support there. It will work when GHES starts supporting Packages REST APIs.