### PR TITLE
Improve `delete-only-untagged-versions` flag and minor bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ This action deletes versions of a package from [GitHub Packages](https://github.
   - `num-old-versions-to-delete` + `ignore-versions`
   - `min-versions-to-keep` + `ignore-versions`
   - `min-versions-to-keep` + `delete-only-pre-release-versions`
+  - `delete-only-untagged-versions`
+  - `min-versions-to-keep` + `delete-only-untagged-versions`
 
 # Scenarios
 

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,8 @@ inputs:
   delete-only-untagged-versions:
     description: >
       Deletes only untagged versions in case of a container package. Does not work for other package types.
+      The number of untagged versions to keep can be specified by min-versions-to-keep.
+      When this is set num-old-versions-to-delete will not be taken into account.
       By default this is set to false
     required: false
     default: "false"

--- a/dist/index.js
+++ b/dist/index.js
@@ -31,6 +31,9 @@ function finalIds(input) {
         (0, operators_1.map)(value => {
             // we need to delete oldest versions first
             value.sort((a, b) => {
+                if (a.created_at === b.created_at) {
+                    return a.id - b.id;
+                }
                 return (new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
             });
             /*

--- a/dist/index.js
+++ b/dist/index.js
@@ -116,8 +116,13 @@ class Input {
             this.token);
     }
     checkInput() {
+        if (this.packageType.toLowerCase() !== 'container') {
+            this.deleteUntaggedVersions = 'false';
+        }
         if (this.numOldVersionsToDelete > 1 &&
-            (this.minVersionsToKeep >= 0 || this.deletePreReleaseVersions === 'true')) {
+            (this.minVersionsToKeep >= 0 ||
+                this.deletePreReleaseVersions === 'true' ||
+                this.deleteUntaggedVersions === 'true')) {
             return false;
         }
         if (this.packageType === '' || this.packageName === '') {
@@ -128,8 +133,9 @@ class Input {
                 this.minVersionsToKeep > 0 ? this.minVersionsToKeep : 0;
             this.ignoreVersions = new RegExp('^(0|[1-9]\\d*)((\\.(0|[1-9]\\d*))*)$');
         }
-        if (this.packageType.toLowerCase() !== 'container') {
-            this.deleteUntaggedVersions = 'false';
+        if (this.deleteUntaggedVersions === 'true') {
+            this.minVersionsToKeep =
+                this.minVersionsToKeep > 0 ? this.minVersionsToKeep : 0;
         }
         if (this.minVersionsToKeep >= 0) {
             this.numOldVersionsToDelete = 0;

--- a/src/delete.ts
+++ b/src/delete.ts
@@ -63,6 +63,9 @@ export function finalIds(input: Input): Observable<string[]> {
       map(value => {
         // we need to delete oldest versions first
         value.sort((a, b) => {
+          if (a.created_at === b.created_at) {
+            return a.id - b.id
+          }
           return (
             new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
           )

--- a/src/input.ts
+++ b/src/input.ts
@@ -63,9 +63,15 @@ export class Input {
   }
 
   checkInput(): boolean {
+    if (this.packageType.toLowerCase() !== 'container') {
+      this.deleteUntaggedVersions = 'false'
+    }
+
     if (
       this.numOldVersionsToDelete > 1 &&
-      (this.minVersionsToKeep >= 0 || this.deletePreReleaseVersions === 'true')
+      (this.minVersionsToKeep >= 0 ||
+        this.deletePreReleaseVersions === 'true' ||
+        this.deleteUntaggedVersions === 'true')
     ) {
       return false
     }
@@ -80,8 +86,9 @@ export class Input {
       this.ignoreVersions = new RegExp('^(0|[1-9]\\d*)((\\.(0|[1-9]\\d*))*)$')
     }
 
-    if (this.packageType.toLowerCase() !== 'container') {
-      this.deleteUntaggedVersions = 'false'
+    if (this.deleteUntaggedVersions === 'true') {
+      this.minVersionsToKeep =
+        this.minVersionsToKeep > 0 ? this.minVersionsToKeep : 0
     }
 
     if (this.minVersionsToKeep >= 0) {


### PR DESCRIPTION
With release v4.0.0, we introduced `delete-only-untagged-versions` to delete only untagged container versions. This is somewhat equivalent to deleting prerelease versions for other package types.

- We do not allow specifying `num-old-versions-to-delete` along with `delete-only-pre-release-versions`
- When  `delete-only-pre-release-versions` is true, we default `min-versions-to-keep` to 0. 
 
`delete-only-untagged-versions` does not behave in the same way. This is unnecessary inconsistency between two kind of similar flags and this PR aims to fix that.

---

This also includes a minor bug fix where if two versions have same created_at timestamp (rare), then either could get deleted. Added a logic to sort by ID if created_at timestamp matches