### PR TITLE
Added ability to ignore tags when deleting packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ This action deletes versions of a package from [GitHub Packages](https://github.
   # Cannot be used with `num-old-versions-to-delete`.
   delete-only-untagged-versions:
 
+  # If true it will also ignore tags matching the regex provided in `ignore-versions`
+  # Defaults to false.
+  # Can only be used with `ignore-versions`.
+  ignore-versions-include-tags:
+
   # The token used to authenticate with GitHub Packages.
   # Defaults to github.token.
   # Required if the repo running the workflow does not have access to delete the package.
@@ -89,6 +94,8 @@ This action deletes versions of a package from [GitHub Packages](https://github.
   - `min-versions-to-keep` + `delete-only-pre-release-versions`
   - `delete-only-untagged-versions`
   - `min-versions-to-keep` + `delete-only-untagged-versions`
+  - `ignore-versions-include-tags` + `ignore-versions`
+  - `ignore-versions-include-tags` + `ignore-versions` + `min-versions-to-keep`
 
 # Scenarios
 
@@ -106,6 +113,8 @@ This action deletes versions of a package from [GitHub Packages](https://github.
     - [Delete oldest version of a package](#delete-oldest-version-of-a-package)
     - [Delete a specific version of a package](#delete-a-specific-version-of-a-package)
     - [Delete multiple specific versions of a package](#delete-multiple-specific-versions-of-a-package)
+    - [Delete all white ignoring particular tags](#delete-all-while-ignoring-particular-tags)
+    - [Delete all except y latest versions while ignoring particular tags](#delete-all-except-y-latest-versions-while-ignoring-particular-tags)
 - [License](#license)
 
 
@@ -403,6 +412,44 @@ This action deletes versions of a package from [GitHub Packages](https://github.
       package-name: 'test-package'
       package-type: 'npm'
       token: ${{ secrets.PAT }}
+  ```
+
+  <br>
+
+  ### Delete all while ignoring particular tags
+
+  To delete all while ignoring particular tags, the __package-name__, __ignore-versions-include-tags__ and __ignore-versions__ inputs are required.
+
+  __Example__
+
+  Deletes all versions of a package excluding package containing the `important-tag` tag.
+
+  ```yaml
+  - uses: actions/delete-package-version@v4
+    with:
+      package-name: 'test-package'
+      package-type: 'container'
+      ignore-versions: '^important-tag$'
+      ignore-versions-include-tags: 'true'
+      token: ${{ secrets.PAT }}
+  ```
+
+  ### Delete all except y latest versions while ignoring particular tags
+
+  To delete all except y latest versions while ignoring particular tags, the __package-name__, __min-versions-to-keep__, __ignore-versions-include-tags__  and __ignore-versions__ inputs are required.
+
+  __Example__
+
+  Delete all except latest 3 package versions excluding package containing the `important-tag` tag.
+
+  ```yaml
+  - uses: actions/delete-package-versions@v4
+    with: 
+      package-name: 'test-package'
+      package-type: 'container'
+      min-versions-to-keep: 3
+      ignore-versions: '^important-tag$'
+      ignore-versions-include-tags: 'true'
   ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This action deletes versions of a package from [GitHub Packages](https://github.
     - [Delete oldest version of a package](#delete-oldest-version-of-a-package)
     - [Delete a specific version of a package](#delete-a-specific-version-of-a-package)
     - [Delete multiple specific versions of a package](#delete-multiple-specific-versions-of-a-package)
-    - [Delete all white ignoring particular tags](#delete-all-while-ignoring-particular-tags)
+    - [Delete all while ignoring particular tags](#delete-all-while-ignoring-particular-tags)
     - [Delete all except y latest versions while ignoring particular tags](#delete-all-except-y-latest-versions-while-ignoring-particular-tags)
 - [License](#license)
 

--- a/__tests__/version/get-version.test.ts
+++ b/__tests__/version/get-version.test.ts
@@ -114,8 +114,10 @@ describe('get versions tests -- mock rest', () => {
           expect(result.versions[i].created_at).toBe(resp[i].created_at)
           if (i < numTaggedVersions) {
             expect(result.versions[i].tagged).toBe(true)
+            expect(result.versions[i].tags.length).toBe(1)
           } else {
             expect(result.versions[i].tagged).toBe(false)
+            expect(result.versions[i].tags.length).toBe(0)
           }
         }
         expect(result.paginate).toBe(true)

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,13 @@ inputs:
     required: false
     default: "false"
 
+  ignore-versions-include-tags:
+    description: >
+      Next to the version also ignore tags matching the ignore-versions regex. 
+      By default this is set to false
+    required: false
+    default: "false"
+
   token:
     description: >
       Token with the necessary scopes to delete package versions.

--- a/dist/index.js
+++ b/dist/index.js
@@ -41,6 +41,10 @@ function finalIds(input) {
               Then compute number of versions to delete (toDelete) based on the inputs.
               */
             value = value.filter(info => !input.ignoreVersions.test(info.version));
+            // Filter out tags that are to be ignored only when including tags is enabled
+            if (input.includeTags === 'true') {
+                value = value.filter(info => !info.tags.some(tag => input.ignoreVersions.test(tag)));
+            }
             if (input.deleteUntaggedVersions === 'true') {
                 value = value.filter(info => !info.tagged);
             }
@@ -95,7 +99,8 @@ const defaultParams = {
     ignoreVersions: new RegExp(''),
     deletePreReleaseVersions: '',
     token: '',
-    deleteUntaggedVersions: ''
+    deleteUntaggedVersions: '',
+    includeTags: ''
 };
 class Input {
     constructor(params) {
@@ -111,6 +116,7 @@ class Input {
         this.token = validatedParams.token;
         this.numDeleted = 0;
         this.deleteUntaggedVersions = validatedParams.deleteUntaggedVersions;
+        this.includeTags = validatedParams.includeTags;
     }
     hasOldestVersionQueryInfo() {
         return !!(this.owner &&
@@ -231,17 +237,18 @@ function getOldestVersions(owner, packageName, packageType, numVersions, page, t
     }), (0, operators_1.map)(response => {
         const resp = {
             versions: response.data.map((version) => {
-                let tagged = false;
+                let tags = [];
                 if (package_type === 'container' &&
                     version.metadata &&
                     version.metadata.container) {
-                    tagged = version.metadata.container.tags.length > 0;
+                    tags = version.metadata.container.tags;
                 }
                 return {
                     id: version.id,
                     version: version.name,
                     created_at: version.created_at,
-                    tagged
+                    tagged: tags.length > 0,
+                    tags
                 };
             }),
             page,
@@ -43941,7 +43948,8 @@ function getActionInput() {
         ignoreVersions: RegExp((0, core_1.getInput)('ignore-versions')),
         deletePreReleaseVersions: (0, core_1.getInput)('delete-only-pre-release-versions').toLowerCase(),
         token: (0, core_1.getInput)('token'),
-        deleteUntaggedVersions: (0, core_1.getInput)('delete-only-untagged-versions').toLowerCase()
+        deleteUntaggedVersions: (0, core_1.getInput)('delete-only-untagged-versions').toLowerCase(),
+        includeTags: (0, core_1.getInput)('ignore-versions-include-tags').toLowerCase()
     });
 }
 function run() {

--- a/src/delete.ts
+++ b/src/delete.ts
@@ -76,6 +76,13 @@ export function finalIds(input: Input): Observable<string[]> {
           */
         value = value.filter(info => !input.ignoreVersions.test(info.version))
 
+        // Filter out tags that are to be ignored only when including tags is enabled
+        if (input.includeTags === 'true') {
+          value = value.filter(
+            info => !info.tags.some(tag => input.ignoreVersions.test(tag))
+          )
+        }
+
         if (input.deleteUntaggedVersions === 'true') {
           value = value.filter(info => !info.tagged)
         }

--- a/src/input.ts
+++ b/src/input.ts
@@ -9,6 +9,7 @@ export interface InputParams {
   token?: string
   deletePreReleaseVersions?: string
   deleteUntaggedVersions?: string
+  includeTags?: string
 }
 
 const defaultParams = {
@@ -21,7 +22,8 @@ const defaultParams = {
   ignoreVersions: new RegExp(''),
   deletePreReleaseVersions: '',
   token: '',
-  deleteUntaggedVersions: ''
+  deleteUntaggedVersions: '',
+  includeTags: ''
 }
 
 export class Input {
@@ -36,6 +38,7 @@ export class Input {
   token: string
   numDeleted: number
   deleteUntaggedVersions: string
+  includeTags: string
 
   constructor(params?: InputParams) {
     const validatedParams: Required<InputParams> = {...defaultParams, ...params}
@@ -51,6 +54,7 @@ export class Input {
     this.token = validatedParams.token
     this.numDeleted = 0
     this.deleteUntaggedVersions = validatedParams.deleteUntaggedVersions
+    this.includeTags = validatedParams.includeTags
   }
 
   hasOldestVersionQueryInfo(): boolean {
@@ -65,6 +69,7 @@ export class Input {
   checkInput(): boolean {
     if (this.packageType.toLowerCase() !== 'container') {
       this.deleteUntaggedVersions = 'false'
+      this.includeTags = 'false'
     }
 
     if (

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,8 @@ function getActionInput(): Input {
     token: getInput('token'),
     deleteUntaggedVersions: getInput(
       'delete-only-untagged-versions'
-    ).toLowerCase()
+    ).toLowerCase(),
+    includeTags: getInput('ignore-versions-include-tags').toLowerCase()
   })
 }
 

--- a/src/version/get-versions.ts
+++ b/src/version/get-versions.ts
@@ -9,6 +9,7 @@ export interface RestVersionInfo {
   version: string
   created_at: string
   tagged: boolean
+  tags: string[]
 }
 
 export interface RestQueryInfo {
@@ -57,20 +58,22 @@ export function getOldestVersions(
     map(response => {
       const resp = {
         versions: response.data.map((version: GetVersionsResponse[0]) => {
-          let tagged = false
+          let tags: string[] = []
+
           if (
             package_type === 'container' &&
             version.metadata &&
             version.metadata.container
           ) {
-            tagged = version.metadata.container.tags.length > 0
+            tags = version.metadata.container.tags
           }
 
           return {
             id: version.id,
             version: version.name,
             created_at: version.created_at,
-            tagged
+            tagged: tags.length > 0,
+            tags
           }
         }),
         page,


### PR DESCRIPTION
This PR contains a possible implementation for #88. This implementation adds a input parameter to enable ignoring of tags based on the existing `ignore-versions` input