### PR TITLE
[help appreciated] Support multi arch packages / Solving "Manifest Unknown" error

### DIFF
--- a/src/delete.ts
+++ b/src/delete.ts
@@ -112,12 +112,6 @@ export function finalIds(input: Input): Observable<string[]> {
         }
 
         let toDelete = 0
-        if (input.minVersionsToKeep < 0) {
-          toDelete = Math.min(
-            value.length,
-            Math.min(input.numOldVersionsToDelete, RATE_LIMIT)
-          )
-        } else {
           /*
             Keeps only n packages
             If deleteUntaggedVersions is true, then all tagged versions are kept, plus a number of untagged versions (minVersionsToKeep)
@@ -126,8 +120,15 @@ export function finalIds(input: Input): Observable<string[]> {
             Problem with current code: when determining n-versions, also subpackages are counted (rather than just counting real packages)
           */
          // PSEUDOCODE TO FIX THIS:  
-         // Step 1: Create an array that does not include the subpackages to calculate which ones need to be retained
-          const valueWithoutSub = value.filter(info => (!subIdsArray.some(subIdInfo => subIdInfo.subId === info.id)))
+         // Step 1: Create an array that does not include the subpackages to calculate which ones need to be retained / deleted
+        const valueWithoutSub = value.filter(info => (!subIdsArray.some(subIdInfo => subIdInfo.subId === info.id)))   
+
+        if (input.minVersionsToKeep < 0) {
+          toDelete = Math.min(
+            valueWithoutSub.length,
+            Math.min(input.numOldVersionsToDelete, RATE_LIMIT)
+          )
+        } else {
           toDelete = Math.min(
             valueWithoutSub.length - input.minVersionsToKeep,
             RATE_LIMIT

--- a/src/version/get-versions.ts
+++ b/src/version/get-versions.ts
@@ -70,7 +70,16 @@ export function getOldestVersions(
             id: version.id,
             version: version.name,
             created_at: version.created_at,
-            tagged
+            tagged,
+            subIds: [] <<<<<<<<<<<<<<<<<<<<<<<<<<<<< First, we need to get for all packages the subIds (if they have any)
+              Example: https://github.com/ManiMatter/decluttarr/pkgs/container/decluttarr/204442395?tag=v1.38.0
+              Package v1.38.0: sha256:b4a9b04d8c0a5ab9f400f7f64f8be20d9951a996fd00882a936087af8f5ce43d
+              Has 3 Sub-IDs:
+                linux/amd64:      sha256:c2dfb515fd9a6ad396fe6a48cd3e535b4079b467cb691bcb3faede6889089d6e
+                linux/arm64:      sha256:59b2aa2e04cc6b3391f612833e87bbd0c4fdfddb04845b8e8f0365a45e90151c
+                unknown/unknown:  sha256:6dfc07ab69cbe95303f51fed14b40a9574bbebbb3501d7aec481d184a8321c91   
+
+
           }
         }),
         page,

--- a/src/version/get-versions.ts
+++ b/src/version/get-versions.ts
@@ -71,14 +71,14 @@ export function getOldestVersions(
             version: version.name,
             created_at: version.created_at,
             tagged,
-            subIds: [] <<<<<<<<<<<<<<<<<<<<<<<<<<<<< First, we need to get for all packages the subIds (if they have any)
+            subIds: [] /* <<<<<<<<<<<<<<<<<<<<<<<<<<<<< First, we need to get for all packages the subIds (if they have any)
               Example: https://github.com/ManiMatter/decluttarr/pkgs/container/decluttarr/204442395?tag=v1.38.0
               Package v1.38.0: sha256:b4a9b04d8c0a5ab9f400f7f64f8be20d9951a996fd00882a936087af8f5ce43d
               Has 3 Sub-IDs:
                 linux/amd64:      sha256:c2dfb515fd9a6ad396fe6a48cd3e535b4079b467cb691bcb3faede6889089d6e
                 linux/arm64:      sha256:59b2aa2e04cc6b3391f612833e87bbd0c4fdfddb04845b8e8f0365a45e90151c
                 unknown/unknown:  sha256:6dfc07ab69cbe95303f51fed14b40a9574bbebbb3501d7aec481d184a8321c91   
-
+              */
 
           }
         }),


### PR DESCRIPTION
Fixes https://github.com/actions/delete-package-versions/issues/90

Hi @cwille97 , @takost 
apologies for tagging you in this. I saw you have recently contributed to this project, and I was hoping that we can together solve the issue above.

The problem we want to solve is that for multi-architecture packages, the current "delete-package-versions" action does not work, since it kills the individual packages of the architectures, and keeping only the "parent" shell that points to the respective packages.

```
Example: 
https://github.com/ManiMatter/decluttarr/pkgs/container/decluttarr/204442395?tag=v1.38.0

Running the action would keep the main package  v1.38.0 (sha256:b4a9b04d8c0a5ab9f400f7f64f8be20d9951a996fd00882a936087af8f5ce43d) 

but it would lose the 3 Sub-IDs:
linux/amd64:      sha256:c2dfb515fd9a6ad396fe6a48cd3e535b4079b467cb691bcb3faede6889089d6e
linux/arm64:      sha256:59b2aa2e04cc6b3391f612833e87bbd0c4fdfddb04845b8e8f0365a45e90151c
unknown/unknown:  sha256:6dfc07ab69cbe95303f51fed14b40a9574bbebbb3501d7aec481d184a8321c91   

On pulling the main package, the user would then get "manifest unknown" error
```

I have an idea how it could be fixed, and it does not seem to be crazy difficult conceptually.
Unfortunately gitActions and typescript are not my forte, and what I have prepared so far is a "pseudo code".

My idea would be that we enhance the code on two points:
1) When we fetch the package information, we also fetch a list of subIDs contained in the package (e.g. for a parent package it would have the package IDs of the underlying architectures; for the architecture packages that subID would be empty)
2) We change the function finalIds as proposed in my code, which would "shield" those packages from deletion that are not tagged but are part of a parent package that is tagged

It would be fantastic if you chimed in with your skills :) 

Let me know what you think