### PR TITLE
Add workflow file for publishing releases to immutable action package

### DIFF
--- a/.github/workflows/publish-immutable-action.yml
+++ b/.github/workflows/publish-immutable-action.yml
@@ -1,0 +1,23 @@
+name: "Publish Immutable Action Version"
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
+      packages: write
+
+    steps:
+    - name: Checking out
+      uses: actions/checkout@v4
+    - name: Publish
+      id: publish
+      uses: actions/publish-immutable-action@0.0.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-immutable-action.yml
+++ b/.github/workflows/publish-immutable-action.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      attestations: write
       id-token: write
       packages: write
 


### PR DESCRIPTION
This workflow file publishes new action releases to the immutable action package of the same name as this repo. 

This is part of the Immutable Actions project which is not yet fully released to the public. First party actions like this one are part of our initial testing of this feature.